### PR TITLE
Parser cleanup

### DIFF
--- a/bdf-parser/Cargo.toml
+++ b/bdf-parser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bdf-parser"
 description = "Parse BDF files"
 version = "0.1.0"
+edition = "2018"
 authors = ["James Waples <jamwaffles@gmail.com>"]
 repository = "https://github.com/jamwaffles/embedded-fonts"
 documentation = "https://jamwaffles.github.io/embedded-fonts"

--- a/bdf-parser/Cargo.toml
+++ b/bdf-parser/Cargo.toml
@@ -19,9 +19,9 @@ exclude = [
 travis-ci = { repository = "jamwaffles/embedded-fonts", branch = "master" }
 
 [dependencies]
-nom = "5.0.0"
+nom = "6.0.0"
 
 [dev-dependencies]
 chardet = "0.2.4"
 encoding = "0.2.33"
-maplit = "1.0.1"
+maplit = "1.0.2"

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -1,8 +1,8 @@
 use nom::{
     bytes::complete::{tag, take_until},
-    character::{complete::multispace0, is_hex_digit, streaming::space1},
+    character::{complete::multispace0, is_hex_digit},
     combinator::{map_opt, opt},
-    sequence::{delimited, separated_pair},
+    sequence::delimited,
     IResult, ParseTo,
 };
 
@@ -38,7 +38,7 @@ fn glyph_swidth(input: &[u8]) -> IResult<&[u8], Vec2> {
 }
 
 fn glyph_bounding_box(input: &[u8]) -> IResult<&[u8], BoundingBox> {
-    statement("BBX", separated_pair(unsigned_xy, space1, signed_xy))(input)
+    statement("BBX", BoundingBox::parse)(input)
 }
 
 fn glyph_bitmap(input: &[u8]) -> IResult<&[u8], Vec<u32>> {
@@ -164,7 +164,10 @@ ENDCHAR"#;
                     name: "ZZZZ".to_string(),
                     charcode: 65,
                     bitmap: vec![0x00000000, 0x18242442, 0x427e4242, 0x42420000],
-                    bounding_box: ((8, 16), (0, -2)),
+                    bounding_box: BoundingBox {
+                        size: (8, 16),
+                        offset: (0, -2),
+                    },
                 }
             ))
         );
@@ -188,7 +191,10 @@ ENDCHAR"#;
                 EMPTY,
                 Glyph {
                     bitmap: vec![],
-                    bounding_box: ((0, 0), (0, 0)),
+                    bounding_box: BoundingBox {
+                        size: (0, 0),
+                        offset: (0, 0),
+                    },
                     charcode: -1i32,
                     name: "000".to_string(),
                 }
@@ -214,7 +220,10 @@ ENDCHAR"#;
                 EMPTY,
                 Glyph {
                     bitmap: vec![],
-                    bounding_box: ((0, 0), (0, 0)),
+                    bounding_box: BoundingBox {
+                        size: (0, 0),
+                        offset: (0, 0),
+                    },
                     charcode: 0,
                     name: "000".to_string(),
                 }

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -1,5 +1,5 @@
 use nom::{
-    bytes::complete::{tag, take_until, take_while_m_n},
+    bytes::complete::{tag, take, take_until},
     character::complete::multispace0,
     combinator::{map, map_parser, map_res, opt},
     multi::many0,
@@ -62,9 +62,7 @@ fn parse_bitmap(input: &str) -> IResult<&str, Vec<u8>> {
 }
 
 fn parse_hex_byte(input: &str) -> IResult<&str, u8> {
-    map_res(take_while_m_n(2, 2, |c: char| c.is_ascii_hexdigit()), |v| {
-        u8::from_str_radix(v, 16)
-    })(input)
+    map_res(take(2usize), |v| u8::from_str_radix(v, 16))(input)
 }
 
 #[cfg(test)]

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -1,130 +1,107 @@
 use nom::{
-    bytes::complete::{tag, take_until},
-    character::{complete::multispace0, is_hex_digit},
-    combinator::{map_opt, opt},
-    sequence::delimited,
-    IResult, ParseTo,
+    bytes::complete::{tag, take_until, take_while_m_n},
+    character::complete::multispace0,
+    combinator::{map, map_parser, map_res, opt},
+    multi::many0,
+    sequence::{delimited, preceded, terminated},
+    IResult,
 };
+use std::convert::TryFrom;
 
 use crate::{helpers::*, BoundingBox};
-
-type Vec2 = (u32, u32);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Glyph {
     pub name: String,
-    pub charcode: i32,
+    pub encoding: Option<char>,
+    pub scalable_width: Option<(u32, u32)>,
+    pub device_width: Option<(u32, u32)>,
     pub bounding_box: BoundingBox,
-    pub bitmap: Vec<u32>,
+    pub bitmap: Vec<u8>,
 }
 
-fn glyph_startchar(input: &[u8]) -> IResult<&[u8], String> {
-    statement(
-        "STARTCHAR",
-        map_opt(take_until_line_ending, |name| name.parse_to()),
+impl Glyph {
+    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
+        let (input, name) = statement("STARTCHAR", parse_string)(input)?;
+        let (input, encoding) = statement("ENCODING", parse_encoding)(input)?;
+        let (input, scalable_width) = opt(statement("SWIDTH", unsigned_xy))(input)?;
+        let (input, device_width) = opt(statement("DWIDTH", unsigned_xy))(input)?;
+        let (input, bounding_box) = statement("BBX", BoundingBox::parse)(input)?;
+        let (input, _) = multispace0(input)?;
+        let (input, bitmap) = parse_bitmap(input)?;
+
+        Ok((
+            input,
+            Self {
+                name,
+                encoding,
+                scalable_width,
+                device_width,
+                bounding_box,
+                bitmap,
+            },
+        ))
+    }
+}
+
+fn parse_string(input: &str) -> IResult<&str, String> {
+    map(take_until_line_ending, String::from)(input)
+}
+
+fn parse_encoding(input: &str) -> IResult<&str, Option<char>> {
+    map(parse_to_i32, |code| {
+        u32::try_from(code).ok().and_then(std::char::from_u32)
+    })(input)
+}
+
+fn parse_bitmap(input: &str) -> IResult<&str, Vec<u8>> {
+    map_parser(
+        delimited(tag("BITMAP"), take_until("ENDCHAR"), tag("ENDCHAR")),
+        preceded(multispace0, many0(terminated(parse_hex_byte, multispace0))),
     )(input)
 }
 
-fn glyph_charcode(input: &[u8]) -> IResult<&[u8], i32> {
-    statement("ENCODING", parse_to_i32)(input)
-}
-
-fn glyph_dwidth(input: &[u8]) -> IResult<&[u8], Vec2> {
-    statement("DWIDTH", unsigned_xy)(input)
-}
-
-fn glyph_swidth(input: &[u8]) -> IResult<&[u8], Vec2> {
-    statement("SWIDTH", unsigned_xy)(input)
-}
-
-fn glyph_bounding_box(input: &[u8]) -> IResult<&[u8], BoundingBox> {
-    statement("BBX", BoundingBox::parse)(input)
-}
-
-fn glyph_bitmap(input: &[u8]) -> IResult<&[u8], Vec<u32>> {
-    let (input, _) = multispace0(input)?;
-    let (input, glyph_data) =
-        delimited(tag("BITMAP"), take_until("ENDCHAR"), tag("ENDCHAR"))(input)?;
-
-    Ok((
-        input,
-        glyph_data
-            .to_vec()
-            .iter()
-            .filter(|d| is_hex_digit(**d))
-            .collect::<Vec<&u8>>()
-            .chunks(8)
-            .map(|c| {
-                c.iter()
-                    .rev()
-                    .enumerate()
-                    .map(|(k, &&v)| {
-                        let digit = v as char;
-                        digit.to_digit(16).unwrap_or(0) << (k * 4)
-                    })
-                    .sum()
-            })
-            .collect(),
-    ))
-}
-
-pub fn glyph(input: &[u8]) -> IResult<&[u8], Glyph> {
-    let (input, name) = glyph_startchar(input)?;
-    let (input, charcode) = glyph_charcode(input)?;
-    let (input, _) = opt(glyph_swidth)(input)?;
-    let (input, _) = opt(glyph_dwidth)(input)?;
-    let (input, bounding_box) = glyph_bounding_box(input)?;
-    let (input, bitmap) = glyph_bitmap(input)?;
-
-    Ok((
-        input,
-        Glyph {
-            bitmap,
-            bounding_box,
-            charcode,
-            name,
-        },
-    ))
+fn parse_hex_byte(input: &str) -> IResult<&str, u8> {
+    map_res(take_while_m_n(2, 2, |c: char| c.is_ascii_hexdigit()), |v| {
+        u8::from_str_radix(v, 16)
+    })(input)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const EMPTY: &[u8] = &[];
-
     #[test]
     fn it_parses_bitmap_data() {
+        assert_eq!(parse_bitmap("BITMAP\n7e\nENDCHAR"), Ok(("", vec![0x7e])));
+        assert_eq!(parse_bitmap("BITMAP\nff\nENDCHAR"), Ok(("", vec![255])));
         assert_eq!(
-            glyph_bitmap(b"BITMAP\n7e\nENDCHAR".as_ref()),
-            Ok((EMPTY, vec![0x7e]))
+            parse_bitmap("BITMAP\nCCCC\nENDCHAR"),
+            Ok(("", vec![0xcc, 0xcc]))
         );
         assert_eq!(
-            glyph_bitmap(b"BITMAP\nff\nENDCHAR".as_ref()),
-            Ok((EMPTY, vec![255]))
+            parse_bitmap("BITMAP\nffffffff\nENDCHAR"),
+            Ok(("", vec![0xff, 0xff, 0xff, 0xff]))
         );
         assert_eq!(
-            glyph_bitmap(b"BITMAP\nCCCC\nENDCHAR".as_ref()),
-            Ok((EMPTY, vec![0xcccc]))
+            parse_bitmap("BITMAP\nffffffff\naaaaaaaa\nENDCHAR"),
+            Ok(("", vec![0xff, 0xff, 0xff, 0xff, 0xaa, 0xaa, 0xaa, 0xaa]))
         );
         assert_eq!(
-            glyph_bitmap(b"BITMAP\nffffffff\nENDCHAR".as_ref()),
-            Ok((EMPTY, vec![0xffffffff]))
+            parse_bitmap("BITMAP\nff\nff\nff\nff\naa\naa\naa\naa\nENDCHAR"),
+            Ok(("", vec![0xff, 0xff, 0xff, 0xff, 0xaa, 0xaa, 0xaa, 0xaa]))
         );
         assert_eq!(
-            glyph_bitmap(b"BITMAP\nffffffff\naaaaaaaa\nENDCHAR".as_ref()),
-            Ok((EMPTY, vec![0xffffffff, 0xaaaaaaaa]))
-        );
-        assert_eq!(
-            glyph_bitmap(b"BITMAP\nff\nff\nff\nff\naa\naa\naa\naa\nENDCHAR".as_ref()),
-            Ok((EMPTY, vec![0xffffffff, 0xaaaaaaaa]))
-        );
-        assert_eq!(
-            glyph_bitmap(
-                b"BITMAP\n00\n00\n00\n00\n18\n24\n24\n42\n42\n7E\n42\n42\n42\n42\n00\n00\nENDCHAR"
-                    .as_ref()
+            parse_bitmap(
+                "BITMAP\n00\n00\n00\n00\n18\n24\n24\n42\n42\n7E\n42\n42\n42\n42\n00\n00\nENDCHAR"
             ),
-            Ok((EMPTY, vec![0x00000000, 0x18242442, 0x427e4242, 0x42420000]))
+            Ok((
+                "",
+                vec![
+                    0x00, 0x00, 0x00, 0x00, 0x18, 0x24, 0x24, 0x42, 0x42, 0x7e, 0x42, 0x42, 0x42,
+                    0x42, 0x00, 0x00
+                ]
+            ))
         );
     }
 
@@ -154,20 +131,25 @@ BITMAP
 00
 ENDCHAR"#;
 
-        let out = glyph(chardata.as_bytes());
+        let out = Glyph::parse(chardata);
 
         assert_eq!(
             out,
             Ok((
-                EMPTY,
+                "",
                 Glyph {
                     name: "ZZZZ".to_string(),
-                    charcode: 65,
-                    bitmap: vec![0x00000000, 0x18242442, 0x427e4242, 0x42420000],
+                    encoding: Some('A'),
+                    bitmap: vec![
+                        0x00, 0x00, 0x00, 0x00, 0x18, 0x24, 0x24, 0x42, 0x42, 0x7e, 0x42, 0x42,
+                        0x42, 0x42, 0x00, 0x00
+                    ],
                     bounding_box: BoundingBox {
                         size: (8, 16),
                         offset: (0, -2),
                     },
+                    scalable_width: Some((500, 0)),
+                    device_width: Some((8, 0)),
                 }
             ))
         );
@@ -183,20 +165,22 @@ BBX 0 0 0 0
 BITMAP
 ENDCHAR"#;
 
-        let out = glyph(chardata.as_bytes());
+        let out = Glyph::parse(chardata);
 
         assert_eq!(
             out,
             Ok((
-                EMPTY,
+                "",
                 Glyph {
                     bitmap: vec![],
                     bounding_box: BoundingBox {
                         size: (0, 0),
                         offset: (0, 0),
                     },
-                    charcode: -1i32,
+                    encoding: None,
                     name: "000".to_string(),
+                    scalable_width: Some((432, 0)),
+                    device_width: Some((6, 0)),
                 }
             ))
         );
@@ -212,20 +196,22 @@ BBX 0 0 0 0
 BITMAP
 ENDCHAR"#;
 
-        let out = glyph(chardata.as_bytes());
+        let out = Glyph::parse(chardata);
 
         assert_eq!(
             out,
             Ok((
-                EMPTY,
+                "",
                 Glyph {
                     bitmap: vec![],
                     bounding_box: BoundingBox {
                         size: (0, 0),
                         offset: (0, 0),
                     },
-                    charcode: 0,
+                    encoding: Some('\x00'),
                     name: "000".to_string(),
+                    scalable_width: Some((432, 0)),
+                    device_width: Some((6, 0)),
                 }
             ))
         );

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -6,7 +6,7 @@ use nom::{
     IResult, ParseTo,
 };
 
-use super::{helpers::*, BoundingBox};
+use crate::{helpers::*, BoundingBox};
 
 type Vec2 = (u32, u32);
 

--- a/bdf-parser/src/helpers.rs
+++ b/bdf-parser/src/helpers.rs
@@ -7,51 +7,53 @@ use nom::{
     IResult, ParseTo,
 };
 
-pub fn parse_to_i32(input: &[u8]) -> IResult<&[u8], i32> {
-    map_opt(
-        recognize(preceded(opt(one_of("+-")), digit1)),
-        |i: &[u8]| i.parse_to(),
-    )(input)
+pub fn parse_to_i32(input: &str) -> IResult<&str, i32> {
+    map_opt(recognize(preceded(opt(one_of("+-")), digit1)), |i: &str| {
+        i.parse_to()
+    })(input)
 }
 
-pub fn parse_to_u32(input: &[u8]) -> IResult<&[u8], u32> {
-    map_opt(recognize(digit1), |i: &[u8]| i.parse_to())(input)
+pub fn parse_to_u32(input: &str) -> IResult<&str, u32> {
+    map_opt(recognize(digit1), |i: &str| i.parse_to())(input)
 }
 
-fn comment(input: &[u8]) -> IResult<&[u8], String> {
+fn comment(input: &str) -> IResult<&str, String> {
     map_opt(
         delimited(
             tag("COMMENT"),
             opt(preceded(space1, take_until("\n"))),
             line_ending,
         ),
-        |c: Option<&[u8]>| c.map_or(Some(String::from("")), |c| c.parse_to()),
+        |c: Option<&str>| c.map_or(Some(String::from("")), |c| c.parse_to()),
     )(input)
 }
 
-pub fn optional_comments(input: &[u8]) -> IResult<&[u8], Vec<String>> {
-    preceded(multispace0, many0(comment))(input)
+pub fn skip_comments<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+where
+    F: FnMut(&'a str) -> IResult<&'a str, O>,
+{
+    delimited(many0(comment), inner, many0(comment))
 }
 
-pub fn numchars(input: &[u8]) -> IResult<&[u8], u32> {
+pub fn numchars(input: &str) -> IResult<&str, u32> {
     preceded(
         space0,
         preceded(tag("CHARS"), preceded(space0, parse_to_u32)),
     )(input)
 }
 
-pub fn take_until_line_ending(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    take_while(|c| c != b'\n' && c != b'\r')(input)
+pub fn take_until_line_ending(input: &str) -> IResult<&str, &str> {
+    take_while(|c| c != '\n' && c != '\r')(input)
 }
 
 pub fn statement<'a, O, F>(
     keyword: &'a str,
     mut parameters: F,
-) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], O>
+) -> impl FnMut(&'a str) -> IResult<&'a str, O>
 where
-    F: FnMut(&'a [u8]) -> IResult<&'a [u8], O>,
+    F: FnMut(&'a str) -> IResult<&'a str, O>,
 {
-    move |input: &[u8]| {
+    move |input: &str| {
         let (input, _) = multispace0(input)?;
         let (input, _) = tag(keyword)(input)?;
         let (input, _) = space1(input)?;
@@ -63,11 +65,11 @@ where
     }
 }
 
-pub fn signed_xy(input: &[u8]) -> IResult<&[u8], (i32, i32)> {
+pub fn signed_xy(input: &str) -> IResult<&str, (i32, i32)> {
     separated_pair(parse_to_i32, space1, parse_to_i32)(input)
 }
 
-pub fn unsigned_xy(input: &[u8]) -> IResult<&[u8], (u32, u32)> {
+pub fn unsigned_xy(input: &str) -> IResult<&str, (u32, u32)> {
     separated_pair(parse_to_u32, space1, parse_to_u32)(input)
 }
 
@@ -75,29 +77,27 @@ pub fn unsigned_xy(input: &[u8]) -> IResult<&[u8], (u32, u32)> {
 mod tests {
     use super::*;
 
-    const EMPTY: &[u8] = &[];
-
     #[test]
     fn it_takes_until_any_line_ending() {
         assert_eq!(
-            take_until_line_ending(b"Unix line endings\n"),
-            Ok((b"\n".as_ref(), b"Unix line endings".as_ref()))
+            take_until_line_ending("Unix line endings\n"),
+            Ok(("\n".as_ref(), "Unix line endings".as_ref()))
         );
 
         assert_eq!(
-            take_until_line_ending(b"Windows line endings\r\n"),
-            Ok((b"\r\n".as_ref(), b"Windows line endings".as_ref()))
+            take_until_line_ending("Windows line endings\r\n"),
+            Ok(("\r\n".as_ref(), "Windows line endings".as_ref()))
         );
     }
 
     #[test]
     fn it_parses_comments() {
-        let comment_text = b"COMMENT test text\n";
+        let comment_text = "COMMENT test text\n";
         let out = comment(comment_text);
 
-        assert_eq!(out, Ok((EMPTY, "test text".to_string())));
+        assert_eq!(out, Ok(("", "test text".to_string())));
 
         // EMPTY comments
-        assert_eq!(comment(b"COMMENT\n"), Ok((EMPTY, "".to_string())));
+        assert_eq!(comment("COMMENT\n"), Ok(("", "".to_string())));
     }
 }

--- a/bdf-parser/src/helpers.rs
+++ b/bdf-parser/src/helpers.rs
@@ -46,10 +46,10 @@ pub fn take_until_line_ending(input: &[u8]) -> IResult<&[u8], &[u8]> {
 
 pub fn statement<'a, O, F>(
     keyword: &'a str,
-    parameters: F,
-) -> impl Fn(&'a [u8]) -> IResult<&'a [u8], O>
+    mut parameters: F,
+) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], O>
 where
-    F: Fn(&'a [u8]) -> IResult<&'a [u8], O>,
+    F: FnMut(&'a [u8]) -> IResult<&'a [u8], O>,
 {
     move |input: &[u8]| {
         let (input, _) = multispace0(input)?;

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -1,6 +1,14 @@
+use std::str::FromStr;
+
 use nom::{
-    bytes::complete::tag, character::complete::multispace0, character::complete::space1,
-    combinator::map, combinator::opt, multi::many0, sequence::separated_pair, IResult,
+    bytes::complete::tag,
+    character::complete::multispace0,
+    character::complete::space1,
+    combinator::map,
+    combinator::{eof, opt},
+    multi::many0,
+    sequence::{separated_pair, terminated},
+    IResult,
 };
 
 mod glyph;
@@ -14,46 +22,45 @@ use metadata::*;
 use properties::*;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct BDFFont {
+pub struct BdfFont {
     metadata: Option<Metadata>,
     glyphs: Vec<Glyph>,
     properties: Option<Properties>,
 }
 
-pub struct BDFParser<'a> {
-    source: &'a str,
+impl BdfFont {
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, metadata) = opt(header)(input)?;
+        let (input, _) = multispace0(input)?;
+        let (input, properties) = opt(properties)(input)?;
+        let (input, _) = multispace0(input)?;
+        let (input, _) = opt(numchars)(input)?;
+        let (input, _) = multispace0(input)?;
+        let (input, glyphs) = many0(glyph)(input)?;
+        let (input, _) = multispace0(input)?;
+        let (input, _) = opt(tag("ENDFONT"))(input)?;
+        let (input, _) = multispace0(input)?;
+
+        Ok((
+            input,
+            Self {
+                properties,
+                metadata,
+                glyphs,
+            },
+        ))
+    }
 }
 
-impl<'a> BDFParser<'a> {
-    pub fn from_str(source: &'a str) -> Self {
-        Self { source }
+impl FromStr for BdfFont {
+    // TODO: use better error type
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let (_, font) = terminated(Self::parse, eof)(&input.as_bytes()).map_err(|_| ())?;
+
+        Ok(font)
     }
-
-    pub fn parse(&self) -> IResult<&[u8], BDFFont> {
-        bdf(&self.source.as_bytes())
-    }
-}
-
-fn bdf(input: &[u8]) -> IResult<&[u8], BDFFont> {
-    let (input, metadata) = opt(header)(input)?;
-    let (input, _) = multispace0(input)?;
-    let (input, properties) = opt(properties)(input)?;
-    let (input, _) = multispace0(input)?;
-    let (input, _) = opt(numchars)(input)?;
-    let (input, _) = multispace0(input)?;
-    let (input, glyphs) = many0(glyph)(input)?;
-    let (input, _) = multispace0(input)?;
-    let (input, _) = opt(tag("ENDFONT"))(input)?;
-    let (input, _) = multispace0(input)?;
-
-    Ok((
-        input,
-        BDFFont {
-            properties,
-            metadata,
-            glyphs,
-        },
-    ))
 }
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -75,8 +82,6 @@ impl BoundingBox {
 mod tests {
     use super::*;
     use maplit::hashmap;
-
-    const EMPTY: &[u8] = &[];
 
     #[test]
     fn it_parses_a_font_file() {
@@ -108,49 +113,46 @@ ENDCHAR
 ENDFONT
 "#;
 
-        let out = bdf(&chardata.as_bytes());
+        let font = BdfFont::from_str(chardata).unwrap();
 
         assert_eq!(
-            out,
-            Ok((
-                EMPTY,
-                BDFFont {
-                    metadata: Some(Metadata {
-                        version: 2.1,
-                        name: String::from("\"test font\""),
-                        size: (16, (75, 75)),
+            font,
+            BdfFont {
+                metadata: Some(Metadata {
+                    version: 2.1,
+                    name: String::from("\"test font\""),
+                    size: (16, (75, 75)),
+                    bounding_box: BoundingBox {
+                        size: (16, 24),
+                        offset: (0, 0),
+                    }
+                }),
+                glyphs: vec![
+                    Glyph {
+                        bitmap: vec![0x1f01],
                         bounding_box: BoundingBox {
-                            size: (16, 24),
+                            size: (8, 8),
                             offset: (0, 0),
-                        }
-                    }),
-                    glyphs: vec![
-                        Glyph {
-                            bitmap: vec![0x1f01],
-                            bounding_box: BoundingBox {
-                                size: (8, 8),
-                                offset: (0, 0),
-                            },
-                            charcode: 64,
-                            name: "000".to_string(),
                         },
-                        Glyph {
-                            bitmap: vec![0x2f02],
-                            bounding_box: BoundingBox {
-                                size: (8, 8),
-                                offset: (0, 0),
-                            },
-                            charcode: 64,
-                            name: "000".to_string(),
+                        charcode: 64,
+                        name: "000".to_string(),
+                    },
+                    Glyph {
+                        bitmap: vec![0x2f02],
+                        bounding_box: BoundingBox {
+                            size: (8, 8),
+                            offset: (0, 0),
                         },
-                    ],
-                    properties: Some(hashmap! {
-                        "COPYRIGHT".into() => PropertyValue::Text("https://github.com/iconic/open-iconic, SIL OPEN FONT LICENSE".into()),
-                        "FONT_ASCENT".into() => PropertyValue::Int(0),
-                        "FONT_DESCENT".into() => PropertyValue::Int(0),
-                    })
-                }
-            ))
+                        charcode: 64,
+                        name: "000".to_string(),
+                    },
+                ],
+                properties: Some(hashmap! {
+                    "COPYRIGHT".into() => PropertyValue::Text("https://github.com/iconic/open-iconic, SIL OPEN FONT LICENSE".into()),
+                    "FONT_ASCENT".into() => PropertyValue::Int(0),
+                    "FONT_DESCENT".into() => PropertyValue::Int(0),
+                })
+            }
         );
     }
 
@@ -183,83 +185,78 @@ BITMAP
 ENDCHAR
 "#;
 
-        let out = bdf(&chardata.as_bytes());
+        let font = BdfFont::from_str(chardata).unwrap();
 
         assert_eq!(
-            out,
-            Ok((
-                EMPTY,
-                BDFFont {
-                    metadata: Some(Metadata {
-                        version: 2.1,
-                        name: String::from("\"open_iconic_all_1x\""),
-                        size: (16, (75, 75)),
+            font,
+            BdfFont {
+                metadata: Some(Metadata {
+                    version: 2.1,
+                    name: String::from("\"open_iconic_all_1x\""),
+                    size: (16, (75, 75)),
+                    bounding_box: BoundingBox {
+                        size: (16, 16),
+                        offset: (0, 0),
+                    }
+                }),
+                glyphs: vec![
+                    Glyph {
+                        bitmap: vec![0x1f01],
                         bounding_box: BoundingBox {
-                            size: (16, 16),
-                            offset: (0, 0),
-                        }
-                    }),
-                    glyphs: vec![
-                        Glyph {
-                            bitmap: vec![0x1f01],
-                            bounding_box: BoundingBox {
-                                size: (8, 8),
-                                offset: (0, 0)
-                            },
-                            charcode: 64,
-                            name: "000".to_string(),
+                            size: (8, 8),
+                            offset: (0, 0)
                         },
-                        Glyph {
-                            bitmap: vec![0x2f02],
-                            bounding_box: BoundingBox {
-                                size: (8, 8),
-                                offset: (0, 0)
-                            },
-                            charcode: 64,
-                            name: "000".to_string(),
+                        charcode: 64,
+                        name: "000".to_string(),
+                    },
+                    Glyph {
+                        bitmap: vec![0x2f02],
+                        bounding_box: BoundingBox {
+                            size: (8, 8),
+                            offset: (0, 0)
                         },
-                    ],
-                    properties: Some(hashmap! {
-                        "COPYRIGHT".into() => PropertyValue::Text("https://github.com/iconic/open-iconic, SIL OPEN FONT LICENSE".into()),
-                        "FONT_ASCENT".into() => PropertyValue::Int(0),
-                        "FONT_DESCENT".into() => PropertyValue::Int(0),
-                    })
-                }
-            ))
+                        charcode: 64,
+                        name: "000".to_string(),
+                    },
+                ],
+                properties: Some(hashmap! {
+                    "COPYRIGHT".into() => PropertyValue::Text("https://github.com/iconic/open-iconic, SIL OPEN FONT LICENSE".into()),
+                    "FONT_ASCENT".into() => PropertyValue::Int(0),
+                    "FONT_DESCENT".into() => PropertyValue::Int(0),
+                })
+            }
         );
     }
 
     #[test]
     fn it_handles_windows_line_endings() {
         let windows_line_endings = "STARTFONT 2.1\r\nFONT \"windows_test\"\r\nSIZE 10 96 96\r\nFONTBOUNDINGBOX 8 16 0 -4\r\nCHARS 256\r\nSTARTCHAR 0\r\nENCODING 0\r\nSWIDTH 600 0\r\nDWIDTH 8 0\r\nBBX 8 16 0 -4\r\nBITMAP\r\nD5\r\nENDCHAR\r\nENDFONT\r\n";
-        let out = bdf(&windows_line_endings.as_bytes());
+
+        let font = BdfFont::from_str(windows_line_endings).unwrap();
 
         assert_eq!(
-            out,
-            Ok((
-                EMPTY,
-                BDFFont {
-                    metadata: Some(Metadata {
-                        version: 2.1,
-                        name: String::from("\"windows_test\""),
-                        size: (10, (96, 96)),
-                        bounding_box: BoundingBox {
-                            size: (8, 16),
-                            offset: (0, -4)
-                        },
-                    }),
-                    glyphs: vec![Glyph {
-                        bitmap: vec![0xd5],
-                        bounding_box: BoundingBox {
-                            size: (8, 16),
-                            offset: (0, -4)
-                        },
-                        charcode: 0,
-                        name: "0".to_string(),
-                    },],
-                    properties: None
-                }
-            ))
+            font,
+            BdfFont {
+                metadata: Some(Metadata {
+                    version: 2.1,
+                    name: String::from("\"windows_test\""),
+                    size: (10, (96, 96)),
+                    bounding_box: BoundingBox {
+                        size: (8, 16),
+                        offset: (0, -4)
+                    },
+                }),
+                glyphs: vec![Glyph {
+                    bitmap: vec![0xd5],
+                    bounding_box: BoundingBox {
+                        size: (8, 16),
+                        offset: (0, -4)
+                    },
+                    charcode: 0,
+                    name: "0".to_string(),
+                },],
+                properties: None
+            }
         );
     }
 }

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate nom;
-
 use nom::{
     bytes::complete::tag, character::complete::multispace0, combinator::opt, multi::many0, IResult,
 };
@@ -60,12 +58,9 @@ fn bdf(input: &[u8]) -> IResult<&[u8], BDFFont> {
 }
 
 #[cfg(test)]
-#[macro_use]
-extern crate maplit;
-
-#[cfg(test)]
 mod tests {
     use super::*;
+    use maplit::hashmap;
 
     const EMPTY: &[u8] = &[];
 

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -1,5 +1,6 @@
 use nom::{
-    bytes::complete::tag, character::complete::multispace0, combinator::opt, multi::many0, IResult,
+    bytes::complete::tag, character::complete::multispace0, character::complete::space1,
+    combinator::map, combinator::opt, multi::many0, sequence::separated_pair, IResult,
 };
 
 mod glyph;
@@ -11,8 +12,6 @@ use glyph::*;
 use helpers::*;
 use metadata::*;
 use properties::*;
-
-pub type BoundingBox = ((u32, u32), (i32, i32));
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BDFFont {
@@ -55,6 +54,21 @@ fn bdf(input: &[u8]) -> IResult<&[u8], BDFFont> {
             glyphs,
         },
     ))
+}
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct BoundingBox {
+    pub size: (u32, u32),
+    pub offset: (i32, i32),
+}
+
+impl BoundingBox {
+    pub(crate) fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        map(
+            separated_pair(unsigned_xy, space1, signed_xy),
+            |(size, offset)| Self { size, offset },
+        )(input)
+    }
 }
 
 #[cfg(test)]
@@ -105,18 +119,27 @@ ENDFONT
                         version: 2.1,
                         name: String::from("\"test font\""),
                         size: (16, (75, 75)),
-                        bounding_box: ((16, 24), (0, 0)),
+                        bounding_box: BoundingBox {
+                            size: (16, 24),
+                            offset: (0, 0),
+                        }
                     }),
                     glyphs: vec![
                         Glyph {
                             bitmap: vec![0x1f01],
-                            bounding_box: ((8, 8), (0, 0)),
+                            bounding_box: BoundingBox {
+                                size: (8, 8),
+                                offset: (0, 0),
+                            },
                             charcode: 64,
                             name: "000".to_string(),
                         },
                         Glyph {
                             bitmap: vec![0x2f02],
-                            bounding_box: ((8, 8), (0, 0)),
+                            bounding_box: BoundingBox {
+                                size: (8, 8),
+                                offset: (0, 0),
+                            },
                             charcode: 64,
                             name: "000".to_string(),
                         },
@@ -171,18 +194,27 @@ ENDCHAR
                         version: 2.1,
                         name: String::from("\"open_iconic_all_1x\""),
                         size: (16, (75, 75)),
-                        bounding_box: ((16, 16), (0, 0)),
+                        bounding_box: BoundingBox {
+                            size: (16, 16),
+                            offset: (0, 0),
+                        }
                     }),
                     glyphs: vec![
                         Glyph {
                             bitmap: vec![0x1f01],
-                            bounding_box: ((8, 8), (0, 0)),
+                            bounding_box: BoundingBox {
+                                size: (8, 8),
+                                offset: (0, 0)
+                            },
                             charcode: 64,
                             name: "000".to_string(),
                         },
                         Glyph {
                             bitmap: vec![0x2f02],
-                            bounding_box: ((8, 8), (0, 0)),
+                            bounding_box: BoundingBox {
+                                size: (8, 8),
+                                offset: (0, 0)
+                            },
                             charcode: 64,
                             name: "000".to_string(),
                         },
@@ -211,11 +243,17 @@ ENDCHAR
                         version: 2.1,
                         name: String::from("\"windows_test\""),
                         size: (10, (96, 96)),
-                        bounding_box: ((8, 16), (0, -4)),
+                        bounding_box: BoundingBox {
+                            size: (8, 16),
+                            offset: (0, -4)
+                        },
                     }),
                     glyphs: vec![Glyph {
                         bitmap: vec![0xd5],
-                        bounding_box: ((8, 16), (0, -4)),
+                        bounding_box: BoundingBox {
+                            size: (8, 16),
+                            offset: (0, -4)
+                        },
                         charcode: 0,
                         name: "0".to_string(),
                     },],

--- a/bdf-parser/src/metadata.rs
+++ b/bdf-parser/src/metadata.rs
@@ -1,10 +1,11 @@
-use super::{helpers::*, BoundingBox};
 use nom::{
     character::complete::{multispace0, space1},
     combinator::map_opt,
     sequence::{preceded, separated_pair},
     IResult, ParseTo,
 };
+
+use crate::{helpers::*, BoundingBox};
 
 pub type FontSize = (i32, (u32, u32));
 

--- a/bdf-parser/src/metadata.rs
+++ b/bdf-parser/src/metadata.rs
@@ -1,74 +1,70 @@
 use nom::{
     character::complete::{multispace0, space1},
-    combinator::map_opt,
-    sequence::{preceded, separated_pair},
+    combinator::{map, map_opt},
+    sequence::separated_pair,
     IResult, ParseTo,
 };
 
 use crate::{helpers::*, BoundingBox};
 
-pub type FontSize = (i32, (u32, u32));
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct Metadata {
     pub version: f32,
     pub name: String,
-    pub size: FontSize,
+    pub point_size: i32,
+    pub resolution: (u32, u32),
     pub bounding_box: BoundingBox,
 }
-fn metadata_version(input: &[u8]) -> IResult<&[u8], f32> {
-    map_opt(
-        statement("STARTFONT", take_until_line_ending),
-        |v: &[u8]| v.parse_to(),
-    )(input)
+
+impl Metadata {
+    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
+        let (input, version) = skip_comments(metadata_version)(input)?;
+        let (input, name) = skip_comments(metadata_name)(input)?;
+        let (input, (point_size, resolution)) = skip_comments(metadata_size)(input)?;
+        let (input, bounding_box) = skip_comments(metadata_bounding_box)(input)?;
+        let (input, _) = multispace0(input)?;
+
+        Ok((
+            input,
+            Self {
+                version,
+                name,
+                point_size,
+                resolution,
+                bounding_box,
+            },
+        ))
+    }
 }
 
-fn metadata_name(input: &[u8]) -> IResult<&[u8], String> {
-    map_opt(
-        statement("FONT", take_until_line_ending),
-        |name: &[u8]| name.parse_to(),
-    )(input)
+fn metadata_version(input: &str) -> IResult<&str, f32> {
+    map_opt(statement("STARTFONT", take_until_line_ending), |v: &str| {
+        v.parse_to()
+    })(input)
 }
 
-fn metadata_size(input: &[u8]) -> IResult<&[u8], FontSize> {
+fn metadata_name(input: &str) -> IResult<&str, String> {
+    map(statement("FONT", take_until_line_ending), String::from)(input)
+}
+
+fn metadata_size(input: &str) -> IResult<&str, (i32, (u32, u32))> {
     statement("SIZE", separated_pair(parse_to_i32, space1, unsigned_xy))(input)
 }
 
-fn metadata_bounding_box(input: &[u8]) -> IResult<&[u8], BoundingBox> {
+fn metadata_bounding_box(input: &str) -> IResult<&str, BoundingBox> {
     statement("FONTBOUNDINGBOX", BoundingBox::parse)(input)
-}
-
-pub fn header(input: &[u8]) -> IResult<&[u8], Metadata> {
-    let (input, version) = preceded(optional_comments, metadata_version)(input)?;
-    let (input, name) = preceded(optional_comments, metadata_name)(input)?;
-    let (input, size) = preceded(optional_comments, metadata_size)(input)?;
-    let (input, bounding_box) = preceded(optional_comments, metadata_bounding_box)(input)?;
-    let (input, _) = optional_comments(input)?;
-    let (input, _) = multispace0(input)?;
-
-    Ok((
-        input,
-        Metadata {
-            version,
-            name,
-            size,
-            bounding_box,
-        },
-    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const EMPTY: &[u8] = &[];
-
     #[test]
     fn it_parses_the_font_version() {
-        assert_eq!(metadata_version(b"STARTFONT 2.1\n"), Ok((EMPTY, 2.1f32)));
+        assert_eq!(metadata_version("STARTFONT 2.1\n"), Ok(("", 2.1f32)));
 
         // Some fonts are a bit overzealous with their whitespace
-        assert_eq!(metadata_version(b"STARTFONT   2.1\n"), Ok((EMPTY, 2.1f32)));
+        assert_eq!(metadata_version("STARTFONT   2.1\n"), Ok(("", 2.1f32)));
     }
 
     #[test]
@@ -79,13 +75,14 @@ SIZE 16 75 75
 FONTBOUNDINGBOX 16 24 0 0"#;
 
         assert_eq!(
-            header(input.as_bytes()),
+            Metadata::parse(input),
             Ok((
-                EMPTY,
+                "",
                 Metadata {
                     version: 2.1,
                     name: String::from("\"test font\""),
-                    size: (16, (75, 75)),
+                    point_size: 16,
+                    resolution: (75, 75),
                     bounding_box: BoundingBox {
                         size: (16, 24),
                         offset: (0, 0),

--- a/bdf-parser/src/metadata.rs
+++ b/bdf-parser/src/metadata.rs
@@ -35,10 +35,7 @@ fn metadata_size(input: &[u8]) -> IResult<&[u8], FontSize> {
 }
 
 fn metadata_bounding_box(input: &[u8]) -> IResult<&[u8], BoundingBox> {
-    statement(
-        "FONTBOUNDINGBOX",
-        separated_pair(unsigned_xy, space1, signed_xy),
-    )(input)
+    statement("FONTBOUNDINGBOX", BoundingBox::parse)(input)
 }
 
 pub fn header(input: &[u8]) -> IResult<&[u8], Metadata> {
@@ -89,7 +86,10 @@ FONTBOUNDINGBOX 16 24 0 0"#;
                     version: 2.1,
                     name: String::from("\"test font\""),
                     size: (16, (75, 75)),
-                    bounding_box: ((16, 24), (0, 0))
+                    bounding_box: BoundingBox {
+                        size: (16, 24),
+                        offset: (0, 0),
+                    }
                 }
             ))
         );

--- a/bdf-parser/src/properties.rs
+++ b/bdf-parser/src/properties.rs
@@ -9,7 +9,7 @@ use nom::{
 };
 use std::collections::HashMap;
 
-use super::helpers::*;
+use crate::helpers::*;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PropertyValue {
@@ -68,6 +68,7 @@ pub fn properties(input: &[u8]) -> IResult<&[u8], Properties> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use maplit::hashmap;
 
     const EMPTY: &[u8] = &[];
 

--- a/bdf-parser/tests/helpers.rs
+++ b/bdf-parser/tests/helpers.rs
@@ -70,18 +70,10 @@ pub fn read(path: &Path) -> String {
 pub fn test_font_parse(filepath: &Path) -> Result<(), String> {
     let bdf = read(filepath);
 
-    let parser = BDFParser::from_str(&bdf);
+    let font = bdf.parse::<BdfFont>();
 
-    let out = parser.parse();
-
-    match out {
-        Ok((rest, _parsed)) => {
-            if rest.len() > 0 {
-                Err(format!("{} remaining bytes to parse", rest.len()))
-            } else {
-                Ok(())
-            }
-        }
+    match font {
+        Ok(_font) => Ok(()),
         _ => Err(format!("Other error")),
     }
 }


### PR DESCRIPTION
This PR contains a few extensions to the `bdf-parser` crate and some general cleanup. The most important changes are in the `Glyph` struct, which was missing fields for the character width and used to use an inconvenient `Vec<u32>` to store the bitmap data.