### PR TITLE
Improve parser API

### DIFF
--- a/bdf-parser/Cargo.toml
+++ b/bdf-parser/Cargo.toml
@@ -21,6 +21,5 @@ travis-ci = { repository = "jamwaffles/embedded-fonts", branch = "master" }
 
 [dependencies]
 nom = "6.0.1"
-
-[dev-dependencies]
-maplit = "1.0.2"
+strum = { version = "0.20.0", features = ["derive"] }
+thiserror = "1.0.23"

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -15,7 +15,7 @@ pub struct Glyph {
     pub name: String,
     pub encoding: Option<char>,
     pub scalable_width: Option<Coord>,
-    pub device_width: Option<Coord>,
+    pub device_width: Coord,
     pub bounding_box: BoundingBox,
     pub bitmap: Vec<u8>,
 }
@@ -25,7 +25,7 @@ impl Glyph {
         let (input, name) = statement("STARTCHAR", parse_string)(input)?;
         let (input, encoding) = statement("ENCODING", parse_encoding)(input)?;
         let (input, scalable_width) = opt(statement("SWIDTH", Coord::parse))(input)?;
-        let (input, device_width) = opt(statement("DWIDTH", Coord::parse))(input)?;
+        let (input, device_width) = statement("DWIDTH", Coord::parse)(input)?;
         let (input, bounding_box) = statement("BBX", BoundingBox::parse)(input)?;
         let (input, _) = multispace0(input)?;
         let (input, bitmap) = parse_bitmap(input)?;
@@ -145,7 +145,7 @@ ENDCHAR"#;
                         offset: Coord::new(0, -2),
                     },
                     scalable_width: Some(Coord::new(500, 0)),
-                    device_width: Some(Coord::new(8, 0)),
+                    device_width: Coord::new(8, 0),
                 }
             ))
         );
@@ -174,7 +174,7 @@ ENDCHAR"#;
                     encoding: None,
                     name: "000".to_string(),
                     scalable_width: Some(Coord::new(432, 0)),
-                    device_width: Some(Coord::new(6, 0)),
+                    device_width: Coord::new(6, 0),
                 }
             ))
         );
@@ -203,7 +203,7 @@ ENDCHAR"#;
                     encoding: Some('\x00'),
                     name: "000".to_string(),
                     scalable_width: Some(Coord::new(432, 0)),
-                    device_width: Some(Coord::new(6, 0)),
+                    device_width: Coord::new(6, 0),
                 }
             ))
         );

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -8,14 +8,14 @@ use nom::{
 };
 use std::convert::TryFrom;
 
-use crate::{helpers::*, BoundingBox};
+use crate::{helpers::*, BoundingBox, Coord};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Glyph {
     pub name: String,
     pub encoding: Option<char>,
-    pub scalable_width: Option<(u32, u32)>,
-    pub device_width: Option<(u32, u32)>,
+    pub scalable_width: Option<Coord>,
+    pub device_width: Option<Coord>,
     pub bounding_box: BoundingBox,
     pub bitmap: Vec<u8>,
 }
@@ -24,8 +24,8 @@ impl Glyph {
     pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
         let (input, name) = statement("STARTCHAR", parse_string)(input)?;
         let (input, encoding) = statement("ENCODING", parse_encoding)(input)?;
-        let (input, scalable_width) = opt(statement("SWIDTH", unsigned_xy))(input)?;
-        let (input, device_width) = opt(statement("DWIDTH", unsigned_xy))(input)?;
+        let (input, scalable_width) = opt(statement("SWIDTH", Coord::parse))(input)?;
+        let (input, device_width) = opt(statement("DWIDTH", Coord::parse))(input)?;
         let (input, bounding_box) = statement("BBX", BoundingBox::parse)(input)?;
         let (input, _) = multispace0(input)?;
         let (input, bitmap) = parse_bitmap(input)?;
@@ -141,11 +141,11 @@ ENDCHAR"#;
                         0x42, 0x42, 0x00, 0x00
                     ],
                     bounding_box: BoundingBox {
-                        size: (8, 16),
-                        offset: (0, -2)
+                        size: Coord::new(8, 16),
+                        offset: Coord::new(0, -2),
                     },
-                    scalable_width: Some((500, 0)),
-                    device_width: Some((8, 0)),
+                    scalable_width: Some(Coord::new(500, 0)),
+                    device_width: Some(Coord::new(8, 0)),
                 }
             ))
         );
@@ -168,13 +168,13 @@ ENDCHAR"#;
                 Glyph {
                     bitmap: vec![],
                     bounding_box: BoundingBox {
-                        size: (0, 0),
-                        offset: (0, 0)
+                        size: Coord::new(0, 0),
+                        offset: Coord::new(0, 0),
                     },
                     encoding: None,
                     name: "000".to_string(),
-                    scalable_width: Some((432, 0)),
-                    device_width: Some((6, 0)),
+                    scalable_width: Some(Coord::new(432, 0)),
+                    device_width: Some(Coord::new(6, 0)),
                 }
             ))
         );
@@ -197,13 +197,13 @@ ENDCHAR"#;
                 Glyph {
                     bitmap: vec![],
                     bounding_box: BoundingBox {
-                        size: (0, 0),
-                        offset: (0, 0)
+                        size: Coord::new(0, 0),
+                        offset: Coord::new(0, 0),
                     },
                     encoding: Some('\x00'),
                     name: "000".to_string(),
-                    scalable_width: Some((432, 0)),
-                    device_width: Some((6, 0)),
+                    scalable_width: Some(Coord::new(432, 0)),
+                    device_width: Some(Coord::new(6, 0)),
                 }
             ))
         );

--- a/bdf-parser/src/helpers.rs
+++ b/bdf-parser/src/helpers.rs
@@ -3,7 +3,7 @@ use nom::{
     character::complete::{digit1, line_ending, multispace0, one_of, space0, space1},
     combinator::{map_opt, opt, recognize},
     multi::many0,
-    sequence::{delimited, preceded, separated_pair},
+    sequence::{delimited, preceded},
     IResult, ParseTo,
 };
 
@@ -63,14 +63,6 @@ where
 
         Ok((input, p))
     }
-}
-
-pub fn signed_xy(input: &str) -> IResult<&str, (i32, i32)> {
-    separated_pair(parse_to_i32, space1, parse_to_i32)(input)
-}
-
-pub fn unsigned_xy(input: &str) -> IResult<&str, (u32, u32)> {
-    separated_pair(parse_to_u32, space1, parse_to_u32)(input)
 }
 
 #[cfg(test)]

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -1,6 +1,9 @@
 use nom::{
-    bytes::complete::tag, character::complete::multispace0, character::complete::space1,
-    combinator::map, combinator::opt, multi::many0, sequence::separated_pair, IResult,
+    bytes::complete::tag,
+    character::complete::{multispace0, space1},
+    combinator::{map, opt},
+    sequence::separated_pair,
+    IResult,
 };
 use std::str::FromStr;
 
@@ -9,7 +12,7 @@ mod helpers;
 mod metadata;
 mod properties;
 
-pub use glyph::Glyph;
+pub use glyph::{Glyph, Glyphs};
 use helpers::*;
 pub use metadata::Metadata;
 pub use properties::{Properties, Property, PropertyValue};
@@ -21,7 +24,7 @@ pub struct BdfFont {
     pub metadata: Metadata,
 
     /// Glyphs.
-    pub glyphs: Vec<Glyph>,
+    pub glyphs: Glyphs,
 
     /// Properties.
     pub properties: Properties,
@@ -35,7 +38,7 @@ impl BdfFont {
         let (input, _) = multispace0(input)?;
         let (input, _) = opt(numchars)(input)?;
         let (input, _) = multispace0(input)?;
-        let (input, glyphs) = many0(Glyph::parse)(input)?;
+        let (input, glyphs) = Glyphs::parse(input)?;
         let (input, _) = multispace0(input)?;
         let (input, _) = opt(tag("ENDFONT"))(input)?;
         let (input, _) = multispace0(input)?;
@@ -163,7 +166,7 @@ ENDFONT
         );
 
         assert_eq!(
-            font.glyphs,
+            font.glyphs.iter().cloned().collect::<Vec<_>>(),
             vec![
                 Glyph {
                     bitmap: vec![0x1f, 0x01],
@@ -244,7 +247,7 @@ ENDCHAR
         );
 
         assert_eq!(
-            font.glyphs,
+            font.glyphs.iter().cloned().collect::<Vec<_>>(),
             vec![
                 Glyph {
                     bitmap: vec![0x1f, 0x01],
@@ -300,7 +303,7 @@ ENDCHAR
         );
 
         assert_eq!(
-            font.glyphs,
+            font.glyphs.iter().cloned().collect::<Vec<_>>(),
             vec![Glyph {
                 bitmap: vec![0xd5],
                 bounding_box: BoundingBox {

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -173,7 +173,7 @@ ENDFONT
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some(Coord::new(8, 0)),
+                    device_width: Coord::new(8, 0),
                     scalable_width: None,
                 },
                 Glyph {
@@ -184,7 +184,7 @@ ENDFONT
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some(Coord::new(8, 0)),
+                    device_width: Coord::new(8, 0),
                     scalable_width: None,
                 },
             ],
@@ -254,7 +254,7 @@ ENDCHAR
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some(Coord::new(8, 0)),
+                    device_width: Coord::new(8, 0),
                     scalable_width: None,
                 },
                 Glyph {
@@ -265,7 +265,7 @@ ENDCHAR
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some(Coord::new(8, 0)),
+                    device_width: Coord::new(8, 0),
                     scalable_width: None,
                 }
             ]
@@ -309,7 +309,7 @@ ENDCHAR
                 },
                 encoding: Some('\x00'),
                 name: "0".to_string(),
-                device_width: Some(Coord::new(8, 0)),
+                device_width: Coord::new(8, 0),
                 scalable_width: Some(Coord::new(600, 0)),
             },]
         );

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -19,8 +19,10 @@ pub use properties::{Properties, Property, PropertyValue};
 pub struct BdfFont {
     /// Font metadata.
     pub metadata: Option<Metadata>,
+
     /// Glyphs.
     pub glyphs: Vec<Glyph>,
+
     /// Properties.
     pub properties: Properties,
 }
@@ -65,16 +67,46 @@ impl FromStr for BdfFont {
     }
 }
 
+/// Bounding box.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct BoundingBox {
-    pub size: (u32, u32),
-    pub offset: (i32, i32),
+    /// Size of the bounding box.
+    pub size: Coord,
+
+    /// Offset to the lower left corner of the bounding box.
+    pub offset: Coord,
+}
+
+/// Coordinate.
+///
+/// BDF files use a cartesian coordinate system, where the positive half-axis points upwards.
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct Coord {
+    /// X coordinate.
+    pub x: i32,
+
+    /// Y coordinate.
+    pub y: i32,
+}
+
+impl Coord {
+    /// Creates a new coord.
+    pub fn new(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+
+    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
+        map(
+            separated_pair(parse_to_i32, space1, parse_to_i32),
+            |(x, y)| Self::new(x, y),
+        )(input)
+    }
 }
 
 impl BoundingBox {
     pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
         map(
-            separated_pair(unsigned_xy, space1, signed_xy),
+            separated_pair(Coord::parse, space1, Coord::parse),
             |(size, offset)| Self { size, offset },
         )(input)
     }
@@ -122,10 +154,10 @@ ENDFONT
                 version: 2.1,
                 name: String::from("\"test font\""),
                 point_size: 16,
-                resolution: (75, 75),
+                resolution: Coord::new(75, 75),
                 bounding_box: BoundingBox {
-                    size: (16, 24),
-                    offset: (0, 0),
+                    size: Coord::new(16, 24),
+                    offset: Coord::new(0, 0),
                 },
             })
         );
@@ -136,23 +168,23 @@ ENDFONT
                 Glyph {
                     bitmap: vec![0x1f, 0x01],
                     bounding_box: BoundingBox {
-                        size: (8, 8),
-                        offset: (0, 0),
+                        size: Coord::new(8, 8),
+                        offset: Coord::new(0, 0),
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some((8, 0)),
+                    device_width: Some(Coord::new(8, 0)),
                     scalable_width: None,
                 },
                 Glyph {
                     bitmap: vec![0x2f, 0x02],
                     bounding_box: BoundingBox {
-                        size: (8, 8),
-                        offset: (0, 0),
+                        size: Coord::new(8, 8),
+                        offset: Coord::new(0, 0),
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some((8, 0)),
+                    device_width: Some(Coord::new(8, 0)),
                     scalable_width: None,
                 },
             ],
@@ -203,10 +235,10 @@ ENDCHAR
                 version: 2.1,
                 name: String::from("\"open_iconic_all_1x\""),
                 point_size: 16,
-                resolution: (75, 75),
+                resolution: Coord::new(75, 75),
                 bounding_box: BoundingBox {
-                    size: (16, 16),
-                    offset: (0, 0),
+                    size: Coord::new(16, 16),
+                    offset: Coord::new(0, 0),
                 },
             }),
         );
@@ -217,23 +249,23 @@ ENDCHAR
                 Glyph {
                     bitmap: vec![0x1f, 0x01],
                     bounding_box: BoundingBox {
-                        size: (8, 8),
-                        offset: (0, 0),
+                        size: Coord::new(8, 8),
+                        offset: Coord::new(0, 0),
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some((8, 0)),
+                    device_width: Some(Coord::new(8, 0)),
                     scalable_width: None,
                 },
                 Glyph {
                     bitmap: vec![0x2f, 0x02],
                     bounding_box: BoundingBox {
-                        size: (8, 8),
-                        offset: (0, 0),
+                        size: Coord::new(8, 8),
+                        offset: Coord::new(0, 0),
                     },
                     encoding: Some('@'), //64
                     name: "000".to_string(),
-                    device_width: Some((8, 0)),
+                    device_width: Some(Coord::new(8, 0)),
                     scalable_width: None,
                 }
             ]
@@ -259,10 +291,10 @@ ENDCHAR
                 version: 2.1,
                 name: String::from("\"windows_test\""),
                 point_size: 10,
-                resolution: (96, 96),
+                resolution: Coord::new(96, 96),
                 bounding_box: BoundingBox {
-                    size: (8, 16),
-                    offset: (0, -4),
+                    size: Coord::new(8, 16),
+                    offset: Coord::new(0, -4),
                 },
             })
         );
@@ -272,13 +304,13 @@ ENDCHAR
             vec![Glyph {
                 bitmap: vec![0xd5],
                 bounding_box: BoundingBox {
-                    size: (8, 16),
-                    offset: (0, -4),
+                    size: Coord::new(8, 16),
+                    offset: Coord::new(0, -4),
                 },
                 encoding: Some('\x00'),
                 name: "0".to_string(),
-                device_width: Some((8, 0)),
-                scalable_width: Some((600, 0)),
+                device_width: Some(Coord::new(8, 0)),
+                scalable_width: Some(Coord::new(600, 0)),
             },]
         );
 

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -18,7 +18,7 @@ pub use properties::{Properties, Property, PropertyValue};
 #[derive(Debug, Clone, PartialEq)]
 pub struct BdfFont {
     /// Font metadata.
-    pub metadata: Option<Metadata>,
+    pub metadata: Metadata,
 
     /// Glyphs.
     pub glyphs: Vec<Glyph>,
@@ -29,7 +29,7 @@ pub struct BdfFont {
 
 impl BdfFont {
     fn parse(input: &str) -> IResult<&str, Self> {
-        let (input, metadata) = opt(Metadata::parse)(input)?;
+        let (input, metadata) = Metadata::parse(input)?;
         let (input, _) = multispace0(input)?;
         let (input, properties) = Properties::parse(input)?;
         let (input, _) = multispace0(input)?;
@@ -150,7 +150,7 @@ ENDFONT
 
         assert_eq!(
             font.metadata,
-            Some(Metadata {
+            Metadata {
                 version: 2.1,
                 name: String::from("\"test font\""),
                 point_size: 16,
@@ -159,7 +159,7 @@ ENDFONT
                     size: Coord::new(16, 24),
                     offset: Coord::new(0, 0),
                 },
-            })
+            }
         );
 
         assert_eq!(
@@ -231,7 +231,7 @@ ENDCHAR
 
         assert_eq!(
             font.metadata,
-            Some(Metadata {
+            Metadata {
                 version: 2.1,
                 name: String::from("\"open_iconic_all_1x\""),
                 point_size: 16,
@@ -240,7 +240,7 @@ ENDCHAR
                     size: Coord::new(16, 16),
                     offset: Coord::new(0, 0),
                 },
-            }),
+            },
         );
 
         assert_eq!(
@@ -287,7 +287,7 @@ ENDCHAR
 
         assert_eq!(
             font.metadata,
-            Some(Metadata {
+            Metadata {
                 version: 2.1,
                 name: String::from("\"windows_test\""),
                 point_size: 10,
@@ -296,7 +296,7 @@ ENDCHAR
                     size: Coord::new(8, 16),
                     offset: Coord::new(0, -4),
                 },
-            })
+            }
         );
 
         assert_eq!(

--- a/bdf-parser/src/metadata.rs
+++ b/bdf-parser/src/metadata.rs
@@ -5,14 +5,14 @@ use nom::{
     IResult, ParseTo,
 };
 
-use crate::{helpers::*, BoundingBox};
+use crate::{helpers::*, BoundingBox, Coord};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Metadata {
     pub version: f32,
     pub name: String,
     pub point_size: i32,
-    pub resolution: (u32, u32),
+    pub resolution: Coord,
     pub bounding_box: BoundingBox,
 }
 
@@ -47,8 +47,8 @@ fn metadata_name(input: &str) -> IResult<&str, String> {
     map(statement("FONT", take_until_line_ending), String::from)(input)
 }
 
-fn metadata_size(input: &str) -> IResult<&str, (i32, (u32, u32))> {
-    statement("SIZE", separated_pair(parse_to_i32, space1, unsigned_xy))(input)
+fn metadata_size(input: &str) -> IResult<&str, (i32, Coord)> {
+    statement("SIZE", separated_pair(parse_to_i32, space1, Coord::parse))(input)
 }
 
 fn metadata_bounding_box(input: &str) -> IResult<&str, BoundingBox> {
@@ -71,8 +71,8 @@ mod tests {
     fn it_parses_header() {
         let input = r#"STARTFONT 2.1
 FONT "test font"
-SIZE 16 75 75
-FONTBOUNDINGBOX 16 24 0 0"#;
+SIZE 16 75 100
+FONTBOUNDINGBOX 16 24 1 2"#;
 
         assert_eq!(
             Metadata::parse(input),
@@ -82,10 +82,10 @@ FONTBOUNDINGBOX 16 24 0 0"#;
                     version: 2.1,
                     name: String::from("\"test font\""),
                     point_size: 16,
-                    resolution: (75, 75),
+                    resolution: Coord::new(75, 100),
                     bounding_box: BoundingBox {
-                        size: (16, 24),
-                        offset: (0, 0),
+                        size: Coord::new(16, 24),
+                        offset: Coord::new(1, 2),
                     }
                 }
             ))

--- a/embedded-bdf-macros/src/lib.rs
+++ b/embedded-bdf-macros/src/lib.rs
@@ -99,10 +99,11 @@ impl Parse for CharacterRange {
 fn bounding_box_to_rectangle(bounding_box: &BoundingBox) -> Rectangle {
     Rectangle::new(
         Point::new(
-            bounding_box.offset.0,
-            -bounding_box.offset.1 - (bounding_box.size.1 as i32 - 1),
+            bounding_box.offset.x,
+            -bounding_box.offset.y - (bounding_box.size.y as i32 - 1),
         ),
-        Size::new(bounding_box.size.0, bounding_box.size.1),
+        // TODO: check for negative values
+        Size::new(bounding_box.size.x as u32, bounding_box.size.y as u32),
     )
 }
 
@@ -126,9 +127,9 @@ fn glyph_literal(glyph: &Glyph) -> Option<proc_macro2::TokenStream> {
     let rectangle = bounding_box_to_rectangle(&glyph.bounding_box);
     let bounding_box = rectangle_constructor(&rectangle);
 
-    // TODO: how should a missing device_width be handled?
     // TODO: handle height != 0
-    let device_width = glyph.device_width?.0;
+    // TODO: check for negative values
+    let device_width = glyph.device_width.x as u32;
 
     let bitmap = &glyph.bitmap;
     let data = quote! { &[ #( #bitmap ),* ] };

--- a/tools/test-bdf-parser/tests/u8g2_suite.rs
+++ b/tools/test-bdf-parser/tests/u8g2_suite.rs
@@ -1,6 +1,6 @@
-mod helpers;
+use std::{path::Path, ffi::OsStr};
 
-use std::path::Path;
+mod helpers;
 
 use helpers::*;
 
@@ -12,7 +12,11 @@ fn it_parses_all_u8g2_fonts() {
 
     let fonts = collect_font_files(&fontdir).expect("Could not get list of u8g2 fonts");
 
-    let results = fonts.iter().map(|fpath| test_font_parse(fpath));
+    let results = fonts
+        .iter()
+        // u8x8extra.bdf has a broken header
+        .filter(|path| path.file_name() != Some(OsStr::new("u8x8extra.bdf")))
+        .map(|fpath| test_font_parse(fpath));
 
     let mut num_errors = 0;
 


### PR DESCRIPTION
This PR makes the parser API easier to use, by adding methods to get glyphs by their character or to access the pixel data in a bitmap. The other creates don't use this improved API yet and will be ported in a later PR.

@jamwaffles How should we handle reviews in this repo? Should I only bother you with reviews on the parser, which you wrote originally, or would you also like to review changes on the other crates?