### PR TITLE
Use ASCII encoded byte slices in BDF parser

### DIFF
--- a/bdf-parser/Cargo.toml
+++ b/bdf-parser/Cargo.toml
@@ -21,9 +21,9 @@ travis-ci = { repository = "jamwaffles/embedded-fonts", branch = "master" }
 
 [dependencies]
 bstr = "0.2.15"
-nom = "6.0.1"
+nom = "6.1.2"
 strum = { version = "0.20.0", features = ["derive"] }
-thiserror = "1.0.23"
+thiserror = "1.0.24"
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/bdf-parser/Cargo.toml
+++ b/bdf-parser/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
 travis-ci = { repository = "jamwaffles/embedded-fonts", branch = "master" }
 
 [dependencies]
+bstr = "0.2.15"
 nom = "6.0.1"
 strum = { version = "0.20.0", features = ["derive"] }
 thiserror = "1.0.23"

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -39,7 +39,6 @@ impl Glyph {
         let (input, scalable_width) = opt(statement("SWIDTH", Coord::parse))(input)?;
         let (input, device_width) = statement("DWIDTH", Coord::parse)(input)?;
         let (input, bounding_box) = statement("BBX", BoundingBox::parse)(input)?;
-        let (input, _) = multispace0(input)?;
         let (input, bitmap) = parse_bitmap(input)?;
 
         Ok((
@@ -108,7 +107,10 @@ pub struct Glyphs {
 impl Glyphs {
     pub(crate) fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         map(
-            preceded(terminated(opt(numchars), multispace0), many0(Glyph::parse)),
+            preceded(
+                terminated(opt(numchars), multispace0),
+                many0(terminated(Glyph::parse, multispace0)),
+            ),
             |glyphs| Self { glyphs },
         )(input)
     }

--- a/bdf-parser/src/glyph.rs
+++ b/bdf-parser/src/glyph.rs
@@ -1,7 +1,7 @@
 use nom::{
     bytes::complete::{tag, take, take_until},
     character::complete::{multispace0, space0},
-    combinator::{map, map_parser, map_res, opt},
+    combinator::{eof, map, map_parser, map_res, opt},
     multi::many0,
     sequence::{delimited, preceded, terminated},
     IResult,
@@ -33,7 +33,7 @@ pub struct Glyph {
 }
 
 impl Glyph {
-    fn parse(input: &str) -> IResult<&str, Self> {
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, name) = statement("STARTCHAR", parse_string)(input)?;
         let (input, encoding) = statement("ENCODING", parse_encoding)(input)?;
         let (input, scalable_width) = opt(statement("SWIDTH", Coord::parse))(input)?;
@@ -75,25 +75,28 @@ impl Glyph {
     }
 }
 
-fn parse_string(input: &str) -> IResult<&str, String> {
-    map(take_until_line_ending, String::from)(input)
-}
-
-fn parse_encoding(input: &str) -> IResult<&str, Option<char>> {
+fn parse_encoding(input: &[u8]) -> IResult<&[u8], Option<char>> {
     map(parse_to_i32, |code| {
         u32::try_from(code).ok().and_then(std::char::from_u32)
     })(input)
 }
 
-fn parse_bitmap(input: &str) -> IResult<&str, Vec<u8>> {
+fn parse_bitmap(input: &[u8]) -> IResult<&[u8], Vec<u8>> {
     map_parser(
-        delimited(tag("BITMAP"), take_until("ENDCHAR"), tag("ENDCHAR")),
+        delimited(
+            statement("BITMAP", eof),
+            take_until("ENDCHAR"),
+            statement("ENDCHAR", eof),
+        ),
         preceded(multispace0, many0(terminated(parse_hex_byte, multispace0))),
     )(input)
 }
 
-fn parse_hex_byte(input: &str) -> IResult<&str, u8> {
-    map_res(take(2usize), |v| u8::from_str_radix(v, 16))(input)
+fn parse_hex_byte(input: &[u8]) -> IResult<&[u8], u8> {
+    map_res(
+        map_res(take(2usize), |bytes| std::str::from_utf8(bytes)),
+        |v| u8::from_str_radix(v, 16),
+    )(input)
 }
 
 /// Glyphs collection.
@@ -103,7 +106,7 @@ pub struct Glyphs {
 }
 
 impl Glyphs {
-    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
+    pub(crate) fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         map(
             preceded(terminated(opt(numchars), multispace0), many0(Glyph::parse)),
             |glyphs| Self { glyphs },
@@ -121,7 +124,7 @@ impl Glyphs {
     }
 }
 
-fn numchars(input: &str) -> IResult<&str, u32> {
+fn numchars(input: &[u8]) -> IResult<&[u8], u32> {
     preceded(
         space0,
         preceded(tag("CHARS"), preceded(space0, parse_to_u32)),
@@ -131,67 +134,64 @@ fn numchars(input: &str) -> IResult<&str, u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
 
     #[test]
-    fn it_parses_bitmap_data() {
-        assert_eq!(parse_bitmap("BITMAP\n7e\nENDCHAR"), Ok(("", vec![0x7e])));
-        assert_eq!(parse_bitmap("BITMAP\nff\nENDCHAR"), Ok(("", vec![0xff])));
-        assert_eq!(
-            parse_bitmap("BITMAP\nCCCC\nENDCHAR"),
-            Ok(("", vec![0xcc, 0xcc]))
+    fn test_parse_bitmap() {
+        assert_parser_ok!(parse_bitmap(b"BITMAP\n7e\nENDCHAR"), vec![0x7e]);
+        assert_parser_ok!(parse_bitmap(b"BITMAP\nff\nENDCHAR"), vec![0xff]);
+        assert_parser_ok!(parse_bitmap(b"BITMAP\nCCCC\nENDCHAR"), vec![0xcc, 0xcc]);
+        assert_parser_ok!(
+            parse_bitmap(b"BITMAP\nffffffff\nENDCHAR"),
+            vec![0xff, 0xff, 0xff, 0xff]
         );
-        assert_eq!(
-            parse_bitmap("BITMAP\nffffffff\nENDCHAR"),
-            Ok(("", vec![0xff, 0xff, 0xff, 0xff]))
+        assert_parser_ok!(
+            parse_bitmap(b"BITMAP\nffffffff\naaaaaaaa\nENDCHAR"),
+            vec![0xff, 0xff, 0xff, 0xff, 0xaa, 0xaa, 0xaa, 0xaa]
         );
-        assert_eq!(
-            parse_bitmap("BITMAP\nffffffff\naaaaaaaa\nENDCHAR"),
-            Ok(("", vec![0xff, 0xff, 0xff, 0xff, 0xaa, 0xaa, 0xaa, 0xaa]))
+        assert_parser_ok!(
+            parse_bitmap(b"BITMAP\nff\nff\nff\nff\naa\naa\naa\naa\nENDCHAR"),
+            vec![0xff, 0xff, 0xff, 0xff, 0xaa, 0xaa, 0xaa, 0xaa]
         );
-        assert_eq!(
-            parse_bitmap("BITMAP\nff\nff\nff\nff\naa\naa\naa\naa\nENDCHAR"),
-            Ok(("", vec![0xff, 0xff, 0xff, 0xff, 0xaa, 0xaa, 0xaa, 0xaa]))
-        );
-        assert_eq!(
+        assert_parser_ok!(
             parse_bitmap(
-                "BITMAP\n00\n00\n00\n00\n18\n24\n24\n42\n42\n7E\n42\n42\n42\n42\n00\n00\nENDCHAR"
+                b"BITMAP\n00\n00\n00\n00\n18\n24\n24\n42\n42\n7E\n42\n42\n42\n42\n00\n00\nENDCHAR"
             ),
-            Ok((
-                "",
-                vec![
-                    0x00, 0x00, 0x00, 0x00, 0x18, 0x24, 0x24, 0x42, 0x42, 0x7e, 0x42, 0x42, 0x42,
-                    0x42, 0x00, 0x00
-                ]
-            ))
+            vec![
+                0x00, 0x00, 0x00, 0x00, 0x18, 0x24, 0x24, 0x42, 0x42, 0x7e, 0x42, 0x42, 0x42, 0x42,
+                0x00, 0x00
+            ]
         );
     }
 
     /// Returns test data for a single glyph and the expected parsing result
-    fn test_data() -> (&'static str, Glyph) {
+    fn test_data() -> (&'static [u8], Glyph) {
         (
-            r#"STARTCHAR ZZZZ
-ENCODING 65
-SWIDTH 500 0
-DWIDTH 8 0
-BBX 8 16 0 -2
-BITMAP
-00
-00
-00
-00
-18
-24
-24
-42
-42
-7E
-42
-42
-42
-42
-00
-00
-ENDCHAR"#,
+            indoc! {br#"
+                STARTCHAR ZZZZ
+                ENCODING 65
+                SWIDTH 500 0
+                DWIDTH 8 0
+                BBX 8 16 0 -2
+                BITMAP
+                00
+                00
+                00
+                00
+                18
+                24
+                24
+                42
+                42
+                7E
+                42
+                42
+                42
+                42
+                00
+                00
+                ENDCHAR
+            "#},
             Glyph {
                 name: "ZZZZ".to_string(),
                 encoding: Some('A'), //65
@@ -210,10 +210,10 @@ ENDCHAR"#,
     }
 
     #[test]
-    fn it_parses_a_single_char() {
+    fn parse_single_char() {
         let (chardata, expected_glyph) = test_data();
 
-        assert_eq!(Glyph::parse(chardata), Ok(("", expected_glyph.clone())));
+        assert_parser_ok!(Glyph::parse(chardata), expected_glyph.clone());
     }
 
     #[test]
@@ -266,60 +266,58 @@ ENDCHAR"#,
     }
 
     #[test]
-    fn it_parses_negative_encodings() {
-        let chardata = r#"STARTCHAR 000
-ENCODING -1
-SWIDTH 432 0
-DWIDTH 6 0
-BBX 0 0 0 0
-BITMAP
-ENDCHAR"#;
+    fn parse_glyph_with_no_encoding() {
+        let chardata = indoc! {br#"
+            STARTCHAR 000
+            ENCODING -1
+            SWIDTH 432 0
+            DWIDTH 6 0
+            BBX 0 0 0 0
+            BITMAP
+            ENDCHAR
+        "#};
 
-        assert_eq!(
+        assert_parser_ok!(
             Glyph::parse(chardata),
-            Ok((
-                "",
-                Glyph {
-                    bitmap: vec![],
-                    bounding_box: BoundingBox {
-                        size: Coord::new(0, 0),
-                        offset: Coord::new(0, 0),
-                    },
-                    encoding: None,
-                    name: "000".to_string(),
-                    scalable_width: Some(Coord::new(432, 0)),
-                    device_width: Coord::new(6, 0),
-                }
-            ))
+            Glyph {
+                bitmap: vec![],
+                bounding_box: BoundingBox {
+                    size: Coord::new(0, 0),
+                    offset: Coord::new(0, 0),
+                },
+                encoding: None,
+                name: "000".to_string(),
+                scalable_width: Some(Coord::new(432, 0)),
+                device_width: Coord::new(6, 0),
+            }
         );
     }
 
     #[test]
-    fn it_parses_chars_with_no_bitmap() {
-        let chardata = r#"STARTCHAR 000
-ENCODING 0
-SWIDTH 432 0
-DWIDTH 6 0
-BBX 0 0 0 0
-BITMAP
-ENDCHAR"#;
+    fn parse_glyph_with_empty_bitmap() {
+        let chardata = indoc! {br#"
+            STARTCHAR 000
+            ENCODING 0
+            SWIDTH 432 0
+            DWIDTH 6 0
+            BBX 0 0 0 0
+            BITMAP
+            ENDCHAR
+        "#};
 
-        assert_eq!(
+        assert_parser_ok!(
             Glyph::parse(chardata),
-            Ok((
-                "",
-                Glyph {
-                    bitmap: vec![],
-                    bounding_box: BoundingBox {
-                        size: Coord::new(0, 0),
-                        offset: Coord::new(0, 0),
-                    },
-                    encoding: Some('\x00'),
-                    name: "000".to_string(),
-                    scalable_width: Some(Coord::new(432, 0)),
-                    device_width: Coord::new(6, 0),
-                }
-            ))
+            Glyph {
+                bitmap: vec![],
+                bounding_box: BoundingBox {
+                    size: Coord::new(0, 0),
+                    offset: Coord::new(0, 0),
+                },
+                encoding: Some('\x00'),
+                name: "000".to_string(),
+                scalable_width: Some(Coord::new(432, 0)),
+                device_width: Coord::new(6, 0),
+            }
         );
     }
 }

--- a/bdf-parser/src/helpers.rs
+++ b/bdf-parser/src/helpers.rs
@@ -4,7 +4,7 @@ use bstr::ByteSlice;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_until, take_while},
-    character::complete::{digit1, line_ending, one_of, space0, space1},
+    character::complete::{digit1, line_ending, multispace0, one_of, space0, space1},
     combinator::{eof, map, map_opt, opt, recognize},
     multi::many0,
     sequence::{delimited, preceded},
@@ -73,7 +73,7 @@ where
     move |input: &[u8]| {
         let (input, _) = tag(keyword)(input)?;
         let (input, p) = alt((preceded(space1, take_until_line_ending), space0))(input)?;
-        let (input, _) = opt(line_ending)(input)?;
+        let (input, _) = multispace0(input)?;
 
         let (inner_input, output) = parameters(p.trim())?;
         eof(inner_input)?;

--- a/bdf-parser/src/helpers.rs
+++ b/bdf-parser/src/helpers.rs
@@ -1,88 +1,163 @@
+use std::char::REPLACEMENT_CHARACTER;
+
+use bstr::ByteSlice;
 use nom::{
+    branch::alt,
     bytes::complete::{tag, take_until, take_while},
-    character::complete::{digit1, line_ending, multispace0, one_of, space0, space1},
-    combinator::{map_opt, opt, recognize},
+    character::complete::{digit1, line_ending, one_of, space0, space1},
+    combinator::{eof, map, map_opt, opt, recognize},
     multi::many0,
     sequence::{delimited, preceded},
     IResult, ParseTo,
 };
 
-pub fn parse_to_i32(input: &str) -> IResult<&str, i32> {
-    map_opt(recognize(preceded(opt(one_of("+-")), digit1)), |i: &str| {
-        i.parse_to()
-    })(input)
-}
-
-pub fn parse_to_u32(input: &str) -> IResult<&str, u32> {
-    map_opt(recognize(digit1), |i: &str| i.parse_to())(input)
-}
-
-fn comment(input: &str) -> IResult<&str, String> {
+pub fn parse_to_i32(input: &[u8]) -> IResult<&[u8], i32> {
     map_opt(
-        delimited(
-            tag("COMMENT"),
-            opt(preceded(space1, take_until("\n"))),
-            line_ending,
-        ),
-        |c: Option<&str>| c.map_or(Some(String::from("")), |c| c.parse_to()),
+        recognize(preceded(opt(one_of("+-")), digit1)),
+        |i: &[u8]| i.parse_to(),
     )(input)
 }
 
-pub fn skip_comments<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn parse_to_u32(input: &[u8]) -> IResult<&[u8], u32> {
+    map_opt(recognize(digit1), |i: &[u8]| i.parse_to())(input)
+}
+
+fn comment(input: &[u8]) -> IResult<&[u8], String> {
+    map_opt(
+        delimited(
+            tag(b"COMMENT"),
+            opt(preceded(space1, take_until("\n"))),
+            line_ending,
+        ),
+        |c: Option<&[u8]>| c.map_or(Some(String::from("")), |c| c.parse_to()),
+    )(input)
+}
+
+pub fn skip_comments<'a, F, O>(inner: F) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(&'a [u8]) -> IResult<&'a [u8], O>,
 {
     delimited(many0(comment), inner, many0(comment))
 }
 
-pub fn take_until_line_ending(input: &str) -> IResult<&str, &str> {
-    take_while(|c| c != '\n' && c != '\r')(input)
+pub fn parse_string(input: &[u8]) -> IResult<&[u8], String> {
+    map(take_until_line_ending, ascii_to_string_lossy)(input)
 }
 
-pub fn statement<'a, O, F>(
+/// Converts a byte slice into a valid UTF-8 string.
+pub fn ascii_to_string_lossy(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .copied()
+        .map(|byte| {
+            if byte >= 0x80 {
+                REPLACEMENT_CHARACTER
+            } else {
+                byte as char
+            }
+        })
+        .collect()
+}
+
+fn take_until_line_ending(input: &[u8]) -> IResult<&[u8], &[u8]> {
+    take_while(|c| c != b'\n' && c != b'\r')(input)
+}
+
+pub fn statement<'a, F, O>(
     keyword: &'a str,
     mut parameters: F,
-) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(&'a [u8]) -> IResult<&'a [u8], O>,
 {
-    move |input: &str| {
-        let (input, _) = multispace0(input)?;
+    move |input: &[u8]| {
         let (input, _) = tag(keyword)(input)?;
-        let (input, _) = space1(input)?;
-        let (input, p) = parameters(input)?;
-        let (input, _) = space0(input)?;
+        let (input, p) = alt((preceded(space1, take_until_line_ending), space0))(input)?;
         let (input, _) = opt(line_ending)(input)?;
 
-        Ok((input, p))
+        let (inner_input, output) = parameters(p.trim())?;
+        eof(inner_input)?;
+
+        Ok((input, output))
     }
 }
 
 #[cfg(test)]
+#[macro_use]
 mod tests {
+    use nom::combinator::eof;
+
     use super::*;
+
+    /// Asserts that a parsing function has returned `Ok` and no remaining input.
+    macro_rules! assert_parser_ok {
+        ($left:expr, $right:expr) => {
+            assert_eq!($left, Ok((&[] as &[u8], $right)));
+        };
+    }
 
     #[test]
     fn it_takes_until_any_line_ending() {
         assert_eq!(
-            take_until_line_ending("Unix line endings\n"),
+            take_until_line_ending(b"Unix line endings\n"),
             Ok(("\n".as_ref(), "Unix line endings".as_ref()))
         );
 
         assert_eq!(
-            take_until_line_ending("Windows line endings\r\n"),
+            take_until_line_ending(b"Windows line endings\r\n"),
             Ok(("\r\n".as_ref(), "Windows line endings".as_ref()))
         );
     }
 
     #[test]
-    fn it_parses_comments() {
-        let comment_text = "COMMENT test text\n";
-        let out = comment(comment_text);
+    fn parse_statement_without_parameters() {
+        assert_eq!(
+            statement("KEYWORD", eof)(b"KEYWORD"),
+            Ok((b"".as_ref(), b"".as_ref()))
+        );
 
-        assert_eq!(out, Ok(("", "test text".to_string())));
+        assert_eq!(
+            statement("KEYWORD", eof)(b"KEYWORD\nABC"),
+            Ok((b"ABC".as_ref(), b"".as_ref()))
+        );
+    }
 
-        // EMPTY comments
-        assert_eq!(comment("COMMENT\n"), Ok(("", "".to_string())));
+    #[test]
+    fn parse_statement_with_parameters() {
+        assert_eq!(
+            statement("KEYWORD", parse_string)(b"KEYWORD param"),
+            Ok((b"".as_ref(), "param".to_string())),
+        );
+
+        assert_eq!(
+            statement("KEYWORD", parse_string)(b"KEYWORD    param   \nABC"),
+            Ok((b"ABC".as_ref(), "param".to_string())),
+        );
+    }
+
+    #[test]
+    fn parse_comment() {
+        assert_parser_ok!(comment(b"COMMENT test text\n"), "test text".to_string());
+    }
+
+    #[test]
+    fn parse_empty_comment() {
+        assert_parser_ok!(comment(b"COMMENT\n"), String::new());
+    }
+
+    #[test]
+    fn parse_string_ascii() {
+        assert_eq!(
+            parse_string(b"Test\n"),
+            Ok((b"\n".as_ref(), "Test".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_string_invalid_ascii() {
+        assert_eq!(
+            parse_string(b"Abc\x80\n"),
+            Ok((b"\n".as_ref(), "Abc\u{FFFD}".to_string()))
+        );
     }
 }

--- a/bdf-parser/src/lib.rs
+++ b/bdf-parser/src/lib.rs
@@ -119,17 +119,20 @@ impl BoundingBox {
 }
 
 /// Parser error.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum ParserError {
     /// Metadata.
     #[error("couldn't parse metadata")]
     Metadata,
+
     /// Properties.
     #[error("couldn't parse properties")]
     Properties,
+
     /// Glyphs.
     #[error("couldn't parse glyphs")]
     Glyphs,
+
     /// Unexpected input at the end of the file.
     #[error("unexpected input at the end of the file")]
     EndOfFile,

--- a/embedded-bdf-macros/src/lib.rs
+++ b/embedded-bdf-macros/src/lib.rs
@@ -153,9 +153,9 @@ pub fn include_bdf(input: TokenStream) -> TokenStream {
     path.push(&input.filename.value());
 
     // TODO: handle errors
-    let bdf = fs::read_to_string(&path).unwrap();
+    let bdf = fs::read(&path).unwrap();
 
-    let font = bdf.parse::<BdfFont>().unwrap();
+    let font = BdfFont::parse(&bdf).unwrap();
 
     //TODO: sort glyphs to make it possible to use binary search
     let glyphs: Vec<_> = font

--- a/tools/test-bdf-parser/Cargo.toml
+++ b/tools/test-bdf-parser/Cargo.toml
@@ -5,6 +5,4 @@ authors = ["Ralf Fuest <mail@rfuest.de>"]
 edition = "2018"
 
 [dev-dependencies]
-chardet = "0.2.4"
-encoding = "0.2.33"
 bdf-parser = { path = "../../bdf-parser" }

--- a/tools/test-bdf-parser/tests/helpers.rs
+++ b/tools/test-bdf-parser/tests/helpers.rs
@@ -1,10 +1,5 @@
-use chardet::{charset2encoding, detect};
-use encoding::{label::encoding_from_whatwg_label, DecoderTrap};
 use std::{
-    fs,
-    fs::OpenOptions,
-    io,
-    io::prelude::*,
+    fs, io,
     path::{Path, PathBuf},
 };
 
@@ -34,41 +29,12 @@ pub fn collect_font_files(dir: &Path) -> io::Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-pub fn read(path: &Path) -> String {
-    // open text file
-    let mut fh = OpenOptions::new()
-        .read(true)
-        .open(path)
-        .expect("Could not open file");
-    let mut reader: Vec<u8> = Vec::new();
-
-    // read file
-    fh.read_to_end(&mut reader).expect("Could not read file");
-
-    // detect charset of the file
-    let result = detect(&reader);
-    // result.0 Encode
-    // result.1 Confidence
-    // result.2 Language
-
-    // decode file into utf-8
-    let coder = encoding_from_whatwg_label(charset2encoding(&result.0));
-
-    let utf8reader = coder
-        .unwrap()
-        .decode(&reader, DecoderTrap::Ignore)
-        .expect("Error");
-
-    utf8reader
-}
-
 pub fn test_font_parse(filepath: &Path) -> Result<(), String> {
-    let bdf = read(filepath);
-
-    let font = bdf.parse::<BdfFont>();
+    let bdf = std::fs::read(filepath).unwrap();
+    let font = BdfFont::parse(&bdf);
 
     match font {
         Ok(_font) => Ok(()),
-        _ => Err(format!("Other error")),
+        Err(e) => Err(e.to_string()),
     }
 }


### PR DESCRIPTION
The parser previously expected the BDF input to be a valid UTF-8 string, but the BDF specification requires BDF files to be ASCII encoded. This PR changes the parser to take a `&[u8]` instead of `&str`. Any invalid characters in input files will be replaced by `std::char::REPLACEMENT_CHARACTER`.